### PR TITLE
Implemented GetErrorType method on WebServiceResponse

### DIFF
--- a/idempierewsc/src/org/idempiere/webservice/client/base/Enums.java
+++ b/idempierewsc/src/org/idempiere/webservice/client/base/Enums.java
@@ -808,4 +808,17 @@ public class Enums {
 		 */
 		zh_TW
 	}
+	
+	/**
+	 * Error types on response
+	 * 
+	 * @author antunesleo
+	 *
+	 */
+	public enum ErrorType {
+		RECORD_NOT_EXISTS,
+		SERVICE_TYPE_NOT_EXISTS,
+		UNKNOW_ERROR,
+		EMPTY_ERROR
+	}
 }

--- a/idempierewsc/src/org/idempiere/webservice/client/base/WebServiceResponse.java
+++ b/idempierewsc/src/org/idempiere/webservice/client/base/WebServiceResponse.java
@@ -19,8 +19,10 @@
 
 package org.idempiere.webservice.client.base;
 
-import org.idempiere.webservice.client.base.Enums.WebServiceResponseStatus;
+import org.idempiere.webservice.client.base.Enums.ErrorType;
 import org.idempiere.webservice.client.base.Enums.WebServiceResponseModel;
+import org.idempiere.webservice.client.base.Enums.WebServiceResponseStatus;
+import org.idempiere.webservice.logic.WebServiceResponseLogic;
 
 /**
  * Class to abstract the iDempiere response
@@ -93,6 +95,14 @@ public abstract class WebServiceResponse {
 	 */
 	public void setWebServiceType(String webServiceType) {
 		this.webServiceType = webServiceType;
+	}
+	
+	/**
+	 * Get the error type
+	 * @return
+	 */
+	public ErrorType getErrorType() {
+		return WebServiceResponseLogic.geErrorType(getErrorMessage());
 	}
 
 }

--- a/idempierewsc/src/org/idempiere/webservice/logic/WebServiceResponseLogic.java
+++ b/idempierewsc/src/org/idempiere/webservice/logic/WebServiceResponseLogic.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016 Saúl Piña <sauljabin@gmail.com>.
+ * 
+ * This file is part of idempierewsc.
+ * 
+ * idempierewsc is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * idempierewsc is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with idempierewsc.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.idempiere.webservice.logic;
+
+import org.idempiere.webservice.client.base.Enums.ErrorType;
+
+/**
+ * @author antunesleo
+ * 
+ * This class implements logic on the WebServiceRespons class
+ *
+ */
+
+public class WebServiceResponseLogic {
+	/**
+	 * This method classify the error message
+	 * @param errorMessage
+	 * @return ErrorType
+	 */
+	public static ErrorType geErrorType(String errorMessage) {
+		if (errorMessage == null || errorMessage.isEmpty()) {
+			return ErrorType.EMPTY_ERROR;
+		}
+		if (errorMessage.substring(0, 9).equals("No Record") && errorMessage.contains("in")) {
+			return ErrorType.RECORD_NOT_EXISTS;
+		}
+		if (errorMessage.equals("Service type") && errorMessage.contains("not configured")) {
+			return ErrorType.SERVICE_TYPE_NOT_EXISTS;
+		}
+		return ErrorType.UNKNOW_ERROR;
+	}
+}


### PR DESCRIPTION
This method analyse the error message recieved by the server and classify in a enum of error. This is util to analyse the response and created a condition for handle with each error type. Of course there is a lot of errors type not covered by the method, but it's very useful and can be extended in the future